### PR TITLE
docs: add commit message convention

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,20 +53,20 @@ Les messages de commit sont rédigés en anglais en suivant les conventions suiv
   └─⫸ le type de commit à choisir parmi build|ci|docs|feat|fix|perf|style|refactor|test
 ```
 Le type doit être l'un des choix suivants : 
-  * build: un changement qui affecte le système ou les dépendences
-  * ci: un changement pour la configuration de la CI
-  * docs: un changement dans la documentation
-  * feat: une nouvelle fonctionnalité
-  * fix: la résolution d'un bug
-  * perf: un changement de code améliorant la performance
-  * style: un changement n'affectant que le style
-  * refactor: un changement de l'organisation du code sans changement de fonctionnalité ou performance
-  * test: un changement dans le jeu de tests
+*  build: un changement qui affecte le système ou les dépendences
+*  ci: un changement pour la configuration de la CI
+*  docs: un changement dans la documentation
+*  feat: une nouvelle fonctionnalité
+*  fix: la résolution d'un bug
+*  perf: un changement de code améliorant la performance
+*  style: un changement n'affectant que le style
+*  refactor: un changement de l'organisation du code sans changement de fonctionnalité ou performance
+*  test: un changement dans le jeu de tests
 
 Exemples :
-  * `feat (redux): add reducer case to timer feature`
-  * `fix: timer not displayed`
-  * `test: update reducer timer tests`
-  * `refactor: reorganize header style rules`
+*  `feat (redux): add reducer case to timer feature`
+*  `fix: timer not displayed`
+*  `test: update reducer timer tests`
+*  `refactor: reorganize header style rules`
 
 Il est possible d'ajouter un message plus détaillé en sautant une ligne après la première. Ce dernier peut contenir des informations supplémentaires et/ou un numéro d'issue que le commit permet de cloturer.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,65 +42,31 @@ Pour s'entrainer au process de la _Pull Request_, le repo [first-contributions](
 ## Nommage des commits
 
 Les messages de commit sont rédigés en anglais en suivant les conventions suivantes :
-*Cette spécification est inspirée du [format de message de commit de l'équipe AngularJS](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-format)*
 
-### Format général du message :
-
-```
-<en-tête de message>
-<LIGNE VIDE>
-<corps de message>
-<LIGNE VIDE>
-<pied de message>
-```
-Seule l'en-tête est obligatoire, les autres parties sont optionnelles mais encouragées si pertinentes.
-
-### En-tête de message de commit :
-
-```
+```http
 <type>(<domaine>): <court résumé>
-  │       │             │
-  │       │             └─⫸ résumé rédigé l'impératif présent sans majuscule ni ponctuation
-  │       │
-  │       └─⫸ le domaine auquel s'applique le commit (optionnel)
+  │        │             │
+  │        │             └─⫸ résumé rédigé à l'impératif présent sans majuscule au début ni ponctuation finale
+  │        │
+  │        └─⫸ le domaine auquel s'applique le commit (optionnel)
   │                          
-  └─⫸ le type de commit parmis build|ci|docs|feat|fix|perf|style|refactor|test
+  └─⫸ le type de commit à choisir parmi build|ci|docs|feat|fix|perf|style|refactor|test
 ```
 Le type doit être l'un des choix suivants : 
-* build: un changement qui affecte le système ou les dépendences
-* ci: un changement pour la configuration de la CI
-* docs: un changement dans la documentation
-* feat: une nouvelle fonctionnalité
-* fix: la résolution d'un bug
-* perf: un changement de code améliorant la performance
-* style: un changement n'affectant que le style
-* refactor: un changement de l'organisation du code sans changement de fonctionnalité ou performance
-* test: un changement dans le jeu de tests
+  * build: un changement qui affecte le système ou les dépendences
+  * ci: un changement pour la configuration de la CI
+  * docs: un changement dans la documentation
+  * feat: une nouvelle fonctionnalité
+  * fix: la résolution d'un bug
+  * perf: un changement de code améliorant la performance
+  * style: un changement n'affectant que le style
+  * refactor: un changement de l'organisation du code sans changement de fonctionnalité ou performance
+  * test: un changement dans le jeu de tests
 
 Exemples :
-* `feat (redux): add reducer case to timer feature`
-* `fix: timer not displayed`
-* `test: update reducer timer tests`
-* `refactor: reorganize header style rules`
+  * `feat (redux): add reducer case to timer feature`
+  * `fix: timer not displayed`
+  * `test: update reducer timer tests`
+  * `refactor: reorganize header style rules`
 
-### Corps de message de commit :
-Comme pour l'en tête, rédiger en anglais à l'impératif présent.
-
-Expliquer les motivations du changement : pourquoi le changement devait être fait, comment il a été implémenté et s'il résoud complétement ou seulement en partie la problématique.
-
-### Pied de message de commit :
-
-Le pied de message peut contenir des informations sur les changements majeurs et également les numéro de ticket Jira, d'issue Github  ou tout autre référence que le commit clôt.
-
-```
-BREAKING CHANGE: <court résumé du changement majeur>
-<LIGNE VIDE>
-<description détaillé du changement majeur + informations sur la migration>
-<LIGNE VIDE>
-<LIGNE VIDE>
-fix #<numéro de ticket>
-```
-
-### Commits annulant un précédent commit :
-
-Si le commit annule un précédent commit (commande `git revert`), l'en-tête du commit est alors `revert: <en-tête du commit annulé>` et le corps du message contient le SHA du commit qui est annulé et une description des raisons de cette annulation.
+Il est possible d'ajouter un message plus détaillé en sautant une ligne après la première. Ce dernier peut contenir des informations supplémentaires et/ou un numéro d'issue que le commit permet de cloturer.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,3 +38,69 @@ Il est recommandé de **faire des _commits atomiques_** (commits ne contenant qu
 ## Apprendre à faire une Pull Request
 
 Pour s'entrainer au process de la _Pull Request_, le repo [first-contributions](https://github.com/firstcontributions/first-contributions) donne plus de détails et permet de f'aire un essai "en toute sécurité". :-)
+
+## Nommage des commits
+
+Les messages de commit sont rédigés en anglais en suivant les conventions suivantes :
+*Cette spécification est inspirée du [format de message de commit de l'équipe AngularJS](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-format)*
+
+### Format général du message :
+
+```
+<en-tête de message>
+<LIGNE VIDE>
+<corps de message>
+<LIGNE VIDE>
+<pied de message>
+```
+Seule l'en-tête est obligatoire, les autres parties sont optionnelles mais encouragées si pertinentes.
+
+### En-tête de message de commit :
+
+```
+<type>(<domaine>): <court résumé>
+  │       │             │
+  │       │             └─⫸ résumé rédigé l'impératif présent sans majuscule ni ponctuation
+  │       │
+  │       └─⫸ le domaine auquel s'applique le commit (optionnel)
+  │                          
+  └─⫸ le type de commit parmis build|ci|docs|feat|fix|perf|style|refactor|test
+```
+Le type doit être l'un des choix suivants : 
+* build: un changement qui affecte le système ou les dépendences
+* ci: un changement pour la configuration de la CI
+* docs: un changement dans la documentation
+* feat: une nouvelle fonctionnalité
+* fix: la résolution d'un bug
+* perf: un changement de code améliorant la performance
+* style: un changement n'affectant que le style
+* refactor: un changement de l'organisation du code sans changement de fonctionnalité ou performance
+* test: un changement dans le jeu de tests
+
+Exemples :
+* `feat (redux): add reducer case to timer feature`
+* `fix: timer not displayed`
+* `test: update reducer timer tests`
+* `refactor: reorganize header style rules`
+
+### Corps de message de commit :
+Comme pour l'en tête, rédiger en anglais à l'impératif présent.
+
+Expliquer les motivations du changement : pourquoi le changement devait être fait, comment il a été implémenté et s'il résoud complétement ou seulement en partie la problématique.
+
+### Pied de message de commit :
+
+Le pied de message peut contenir des informations sur les changements majeurs et également les numéro de ticket Jira, d'issue Github  ou tout autre référence que le commit clôt.
+
+```
+BREAKING CHANGE: <court résumé du changement majeur>
+<LIGNE VIDE>
+<description détaillé du changement majeur + informations sur la migration>
+<LIGNE VIDE>
+<LIGNE VIDE>
+fix #<numéro de ticket>
+```
+
+### Commits annulant un précédent commit :
+
+Si le commit annule un précédent commit (commande `git revert`), l'en-tête du commit est alors `revert: <en-tête du commit annulé>` et le corps du message contient le SHA du commit qui est annulé et une description des raisons de cette annulation.


### PR DESCRIPTION
modify contributing.md to add commit message convention
use a template based on angularJS convention
