### PR TITLE
feature throw marble

### DIFF
--- a/src/components/MainPlayerAction/MainPlayerAction.jsx
+++ b/src/components/MainPlayerAction/MainPlayerAction.jsx
@@ -3,26 +3,45 @@ import { useSelector } from "react-redux";
 
 import {
   resetMarbleAmount,
-  selectMarbleAmount,
+  selectCounter,
   startCounter,
   stopCounter,
+  throwMarbles,
 } from "../../features/counter";
 
 export const MainPlayerAction = () => {
-  const marbleAmount = useSelector(selectMarbleAmount);
+  const { marbleAmount, thrownAmount } = useSelector(selectCounter);
   const dispatch = useDispatch();
 
-  const handleClick = () => {
+  const handleReset = () => {
     dispatch(stopCounter());
     dispatch(resetMarbleAmount());
     dispatch(startCounter());
   };
 
   return (
-    <div>
-      {marbleAmount >= 4 ? (
-        <button type="button" onClick={handleClick}>
+    <div className="mainPlayerAction">
+      {marbleAmount + thrownAmount >= 4 ? (
+        <button type="button" onClick={handleReset}>
           Recommencer
+        </button>
+      ) : null}
+      {marbleAmount + thrownAmount >= 10 ? (
+        <button
+          type="button"
+          onClick={() => dispatch(throwMarbles(1))}
+          disabled={marbleAmount < 1}
+        >
+          Jeter 1 bille par terre
+        </button>
+      ) : null}
+      {marbleAmount + thrownAmount >= 20 ? (
+        <button
+          type="button"
+          onClick={() => dispatch(throwMarbles(10))}
+          disabled={marbleAmount < 10}
+        >
+          Jeter 10 billes par terre
         </button>
       ) : null}
     </div>

--- a/src/components/MainPlayerAction/MainPlayerAction.jsx
+++ b/src/components/MainPlayerAction/MainPlayerAction.jsx
@@ -2,29 +2,29 @@ import { useDispatch } from "react-redux";
 import { useSelector } from "react-redux";
 
 import {
-  resetCounter,
-  selectCounterValue,
+  resetMarbleAmount,
+  selectMarbleAmount,
   startCounter,
   stopCounter,
 } from "../../features/counter";
 
 export const MainPlayerAction = () => {
-  const marbleAmount = useSelector(selectCounterValue);
+  const marbleAmount = useSelector(selectMarbleAmount);
   const dispatch = useDispatch();
 
   const handleClick = () => {
     dispatch(stopCounter());
-    dispatch(resetCounter());
+    dispatch(resetMarbleAmount());
     dispatch(startCounter());
   };
 
   return (
-    <>
+    <div>
       {marbleAmount >= 4 ? (
         <button type="button" onClick={handleClick}>
           Recommencer
         </button>
       ) : null}
-    </>
+    </div>
   );
 };

--- a/src/components/MainStory/MainStory.jsx
+++ b/src/components/MainStory/MainStory.jsx
@@ -1,10 +1,10 @@
 import { useEffect } from "react";
 import { useDispatch, useSelector } from "react-redux";
 
-import { selectMarbleAmount, startCounter } from "../../features/counter";
+import { selectCounter, startCounter } from "../../features/counter";
 
 export const MainStory = () => {
-  const marbleAmount = useSelector(selectMarbleAmount);
+  const { marbleAmount, thrownAmount } = useSelector(selectCounter);
   const dispatch = useDispatch();
 
   useEffect(() => {
@@ -12,8 +12,15 @@ export const MainStory = () => {
   }, [dispatch]);
 
   return (
-    <p>{`Vous avez ${marbleAmount} ${
-      marbleAmount <= 1 ? "bille noire" : "billes noires"
-    } dans votre poche.`}</p>
+    <div className="mainStory">
+      <p>{`Vous avez ${marbleAmount} ${
+        marbleAmount <= 1 ? "bille noire" : "billes noires"
+      } dans votre poche.`}</p>
+      {thrownAmount > 0 ? (
+        <p>{`Vous avez laissé tomber ${thrownAmount} ${
+          thrownAmount <= 1 ? "bille" : "billes"
+        } par terre.`}</p>
+      ) : null}
+    </div>
   );
 };

--- a/src/components/MainStory/MainStory.jsx
+++ b/src/components/MainStory/MainStory.jsx
@@ -1,10 +1,10 @@
 import { useEffect } from "react";
 import { useDispatch, useSelector } from "react-redux";
 
-import { selectCounterValue, startCounter } from "../../features/counter";
+import { selectMarbleAmount, startCounter } from "../../features/counter";
 
 export const MainStory = () => {
-  const marbleAmount = useSelector(selectCounterValue);
+  const marbleAmount = useSelector(selectMarbleAmount);
   const dispatch = useDispatch();
 
   useEffect(() => {

--- a/src/features/counter.js
+++ b/src/features/counter.js
@@ -3,6 +3,7 @@ import { createSlice } from "@reduxjs/toolkit";
 const initialState = {
   intervalId: null,
   marbleAmount: 0,
+  thrownAmount: 0,
 };
 
 const counterSlice = createSlice({
@@ -16,11 +17,21 @@ const counterSlice = createSlice({
     storeIntervalId: (state, action) => {
       state.intervalId = action.payload;
     },
+    throwMarbles: (state, action) => {
+      if (state.marbleAmount >= action.payload) {
+        state.thrownAmount += action.payload;
+        state.marbleAmount -= action.payload;
+      }
+    },
   },
 });
 
-export const { incrementMarbleAmount, resetMarbleAmount, storeIntervalId } =
-  counterSlice.actions;
+export const {
+  incrementMarbleAmount,
+  resetMarbleAmount,
+  storeIntervalId,
+  throwMarbles,
+} = counterSlice.actions;
 
 export const startCounter = () => (dispatch) => {
   const intervalId = setInterval(() => {
@@ -34,6 +45,6 @@ export const stopCounter = () => (_, getState) => {
   clearInterval(getState().counter.intervalId);
 };
 
-export const selectMarbleAmount = (state) => state.counter.marbleAmount;
+export const selectCounter = (state) => state.counter;
 
 export default counterSlice.reducer;

--- a/src/features/counter.js
+++ b/src/features/counter.js
@@ -2,29 +2,29 @@ import { createSlice } from "@reduxjs/toolkit";
 
 const initialState = {
   intervalId: null,
-  value: 0,
+  marbleAmount: 0,
 };
 
 const counterSlice = createSlice({
   name: "counter",
   initialState,
   reducers: {
-    incrementCounter: (state) => {
-      state.value += 1;
+    incrementMarbleAmount: (state) => {
+      state.marbleAmount += 1;
     },
-    resetCounter: () => initialState,
+    resetMarbleAmount: () => initialState,
     storeIntervalId: (state, action) => {
       state.intervalId = action.payload;
     },
   },
 });
 
-export const { incrementCounter, resetCounter, storeIntervalId } =
+export const { incrementMarbleAmount, resetMarbleAmount, storeIntervalId } =
   counterSlice.actions;
 
 export const startCounter = () => (dispatch) => {
   const intervalId = setInterval(() => {
-    dispatch(incrementCounter());
+    dispatch(incrementMarbleAmount());
   }, 1000);
 
   dispatch(storeIntervalId(intervalId));
@@ -34,6 +34,6 @@ export const stopCounter = () => (_, getState) => {
   clearInterval(getState().counter.intervalId);
 };
 
-export const selectCounterValue = (state) => state.counter.value;
+export const selectMarbleAmount = (state) => state.counter.marbleAmount;
 
 export default counterSlice.reducer;


### PR DESCRIPTION
User story : Apparition du bouton "Laisser tomber 1 bille par terre" et "Laisser tomber 10 billes par terre"

Ajout de la fonctionnalité pour jeter des billes par terre et de la phrase indiquant le nombre de billes par terre
ajout d'un nouveau state dans le slice du reducer pour le nombre de bille par terre, + renommage du compteur de bille et des reducer associés pour être plus explicite
nouveau reducer dans le redux slice pour mettre à jour le nombre de billes par terre en retirant les billes de l'autre compteur (impossible si pas assez de billes dans le compteur)
ajout du bouton jeter 1 bille par terre (à partir de 10 billes total) et jeter 10 billes par terre (à partir de 100 billes total)