### PR TITLE
Feature cheap bag

### DIFF
--- a/src/components/CountersBox/CountersBox.jsx
+++ b/src/components/CountersBox/CountersBox.jsx
@@ -3,13 +3,13 @@ import { useSelector } from "react-redux";
 import { selectCounter } from "../../features/counter";
 
 export const CountersBox = () => {
-  const { marbleAmount } = useSelector(selectCounter);
+  const { marbleAmount, marbleContainer } = useSelector(selectCounter);
 
   return (
     <>
       <p>{`Vous avez ${marbleAmount} ${
         marbleAmount <= 1 ? "bille noire" : "billes noires"
-      } dans votre poche.`}</p>
+      } dans votre ${marbleContainer.name}.`}</p>
     </>
   );
 };

--- a/src/components/PlayerOptionsBox/PlayerOptionsBox.jsx
+++ b/src/components/PlayerOptionsBox/PlayerOptionsBox.jsx
@@ -9,6 +9,8 @@ import {
   startCounter,
   stopCounter,
   throwMarbles,
+  updateCheapBagEvent,
+  updateMarbleContainer,
 } from "../../features/counter";
 
 const MARBLE_THRESHOLDS = {
@@ -19,8 +21,13 @@ const MARBLE_THRESHOLDS = {
 };
 
 export const PlayerOptionsBox = () => {
-  const { loadFeature, marbleAmount, saveFeature, thrownAmount } =
-    useSelector(selectCounter);
+  const {
+    loadFeature,
+    marbleAmount,
+    saveFeature,
+    thrownAmount,
+    cheapBagEvent,
+  } = useSelector(selectCounter);
   const dispatch = useDispatch();
 
   const handleReset = () => {
@@ -32,6 +39,13 @@ export const PlayerOptionsBox = () => {
   const addSaveAndLoad = () => {
     if (saveFeature) dispatch(addLoadFeature(30));
     else dispatch(addSaveFeature(30));
+  };
+
+  const getCheapBag = () => {
+    dispatch(
+      updateMarbleContainer({ name: "sac de piètre facture", capacity: 50 })
+    );
+    dispatch(updateCheapBagEvent(undefined));
   };
 
   return (
@@ -66,6 +80,11 @@ export const PlayerOptionsBox = () => {
           disabled={marbleAmount < 30}
         >
           Augmenter l'univers des possibles
+        </button>
+      ) : null}
+      {cheapBagEvent && thrownAmount >= cheapBagEvent.button ? (
+        <button type="button" onClick={getCheapBag}>
+          Ramasser le sac de piètre facture
         </button>
       ) : null}
     </>

--- a/src/components/PlayerOptionsBox/PlayerOptionsBox.jsx
+++ b/src/components/PlayerOptionsBox/PlayerOptionsBox.jsx
@@ -43,7 +43,7 @@ export const PlayerOptionsBox = () => {
 
   const getCheapBag = () => {
     dispatch(
-      updateMarbleContainer({ name: "sac de piètre facture", capacity: 50 })
+      updateMarbleContainer({ name: "sac de piètre facture", capacity: 70 })
     );
     dispatch(updateCheapBagEvent(undefined));
   };

--- a/src/components/StoryBox/StoryBox.jsx
+++ b/src/components/StoryBox/StoryBox.jsx
@@ -4,7 +4,8 @@ import { useDispatch, useSelector } from "react-redux";
 import { selectCounter, startCounter } from "../../features/counter";
 
 export const StoryBox = () => {
-  const { thrownAmount } = useSelector(selectCounter);
+  const { marbleAmount, thrownAmount, marbleContainer } =
+    useSelector(selectCounter);
   const dispatch = useDispatch();
 
   useEffect(() => {
@@ -17,6 +18,10 @@ export const StoryBox = () => {
         <p>{`Vous avez laissé tomber ${thrownAmount} ${
           thrownAmount <= 1 ? "bille" : "billes"
         } par terre.`}</p>
+      ) : null}
+      {marbleContainer.name === "poche" &&
+      marbleAmount > marbleContainer.capacity - 10 ? (
+        <p>Vous commencez à avoir beaucoup de billes dans votre poche</p>
       ) : null}
     </>
   );

--- a/src/components/StoryBox/StoryBox.jsx
+++ b/src/components/StoryBox/StoryBox.jsx
@@ -1,7 +1,11 @@
 import { useEffect } from "react";
 import { useDispatch, useSelector } from "react-redux";
 
-import { selectCounter, startCounter } from "../../features/counter";
+import {
+  selectCounter,
+  startCounter,
+  updateMarbleContainer,
+} from "../../features/counter";
 
 export const StoryBox = () => {
   const { marbleAmount, thrownAmount, marbleContainer } =
@@ -11,6 +15,14 @@ export const StoryBox = () => {
   useEffect(() => {
     dispatch(startCounter());
   }, [dispatch]);
+
+  useEffect(() => {
+    if (
+      marbleContainer.name === "poche" &&
+      marbleAmount === marbleContainer.capacity
+    )
+      dispatch(updateMarbleContainer({ name: "poche percée", capacity: 0 }));
+  }, [dispatch, marbleAmount, marbleContainer]);
 
   return (
     <>
@@ -22,6 +34,9 @@ export const StoryBox = () => {
       {marbleContainer.name === "poche" &&
       marbleAmount > marbleContainer.capacity - 10 ? (
         <p>Vous commencez à avoir beaucoup de billes dans votre poche</p>
+      ) : null}
+      {marbleContainer.name === "poche percée" ? (
+        <p>Oups ! Votre poche s'est percée sous le poids des billes !</p>
       ) : null}
     </>
   );

--- a/src/components/StoryBox/StoryBox.jsx
+++ b/src/components/StoryBox/StoryBox.jsx
@@ -4,11 +4,12 @@ import { useDispatch, useSelector } from "react-redux";
 import {
   selectCounter,
   startCounter,
+  updateCheapBagEvent,
   updateMarbleContainer,
 } from "../../features/counter";
 
 export const StoryBox = () => {
-  const { marbleAmount, thrownAmount, marbleContainer } =
+  const { marbleAmount, thrownAmount, marbleContainer, cheapBagEvent } =
     useSelector(selectCounter);
   const dispatch = useDispatch();
 
@@ -20,9 +21,16 @@ export const StoryBox = () => {
     if (
       marbleContainer.name === "poche" &&
       marbleAmount === marbleContainer.capacity
-    )
+    ) {
       dispatch(updateMarbleContainer({ name: "poche percée", capacity: 0 }));
-  }, [dispatch, marbleAmount, marbleContainer]);
+      dispatch(
+        updateCheapBagEvent({
+          sentence: marbleAmount + thrownAmount + 5,
+          button: marbleAmount + thrownAmount + 10,
+        })
+      );
+    }
+  }, [dispatch, marbleAmount, marbleContainer, thrownAmount]);
 
   return (
     <>

--- a/src/components/StoryBox/StoryBox.jsx
+++ b/src/components/StoryBox/StoryBox.jsx
@@ -30,6 +30,16 @@ export const StoryBox = () => {
         })
       );
     }
+    if (
+      marbleContainer.name === "sac de piètre facture" &&
+      marbleAmount === marbleContainer.capacity
+    )
+      dispatch(
+        updateMarbleContainer({
+          name: "sac de piètre facture percé",
+          capacity: 0,
+        })
+      );
   }, [dispatch, marbleAmount, marbleContainer, thrownAmount]);
 
   return (
@@ -39,12 +49,16 @@ export const StoryBox = () => {
           thrownAmount <= 1 ? "bille" : "billes"
         } par terre.`}</p>
       ) : null}
-      {marbleContainer.name === "poche" &&
+      {(marbleContainer.name === "poche" ||
+        marbleContainer.name === "sac de piètre facture") &&
       marbleAmount > marbleContainer.capacity - 10 ? (
-        <p>Vous commencez à avoir beaucoup de billes dans votre poche</p>
+        <p>{`Vous commencez à avoir beaucoup de billes dans votre ${marbleContainer.name}.`}</p>
       ) : null}
-      {marbleContainer.name === "poche percée" ? (
-        <p>Oups ! Votre poche s'est percée sous le poids des billes !</p>
+      {marbleContainer.name.includes("percé") ? (
+        <p>{`Oups ! Votre ${marbleContainer.name.replace(
+          / percée?/,
+          ""
+        )} a cédé sous le poids des billes !`}</p>
       ) : null}
       {cheapBagEvent && thrownAmount >= cheapBagEvent.sentence ? (
         <p>Un sac de piètre facture passe par là, poussé par le vent...</p>

--- a/src/components/StoryBox/StoryBox.jsx
+++ b/src/components/StoryBox/StoryBox.jsx
@@ -46,6 +46,9 @@ export const StoryBox = () => {
       {marbleContainer.name === "poche percée" ? (
         <p>Oups ! Votre poche s'est percée sous le poids des billes !</p>
       ) : null}
+      {cheapBagEvent && thrownAmount >= cheapBagEvent.sentence ? (
+        <p>Un sac de piètre facture passe par là, poussé par le vent...</p>
+      ) : null}
     </>
   );
 };

--- a/src/features/counter.js
+++ b/src/features/counter.js
@@ -6,6 +6,7 @@ const initialState = {
   thrownAmount: 0,
   saveFeature: false,
   loadFeature: false,
+  cheapBagEvent: undefined,
   marbleContainer: { name: "poche", capacity: 35 },
 };
 
@@ -47,6 +48,9 @@ const counterSlice = createSlice({
         state.marbleAmount = action.payload.capacity;
       }
     },
+    updateCheapBagEvent: (state, action) => {
+      state.cheapBagEvent = action.payload;
+    },
   },
 });
 
@@ -58,6 +62,7 @@ export const {
   addLoadFeature,
   addSaveFeature,
   updateMarbleContainer,
+  updateCheapBagEvent,
 } = counterSlice.actions;
 
 export const startCounter = () => (dispatch) => {

--- a/src/features/counter.js
+++ b/src/features/counter.js
@@ -40,6 +40,13 @@ const counterSlice = createSlice({
         state.loadFeature = true;
       }
     },
+    updateMarbleContainer: (state, action) => {
+      state.marbleContainer = action.payload;
+      if (state.marbleAmount > action.payload.capacity) {
+        state.thrownAmount += state.marbleAmount - action.payload.capacity;
+        state.marbleAmount = action.payload.capacity;
+      }
+    },
   },
 });
 
@@ -50,6 +57,7 @@ export const {
   throwMarbles,
   addLoadFeature,
   addSaveFeature,
+  updateMarbleContainer,
 } = counterSlice.actions;
 
 export const startCounter = () => (dispatch) => {

--- a/src/features/counter.js
+++ b/src/features/counter.js
@@ -6,6 +6,7 @@ const initialState = {
   thrownAmount: 0,
   saveFeature: false,
   loadFeature: false,
+  marbleContainer: { name: "poche", capacity: 35 },
 };
 
 const counterSlice = createSlice({

--- a/src/features/counter.js
+++ b/src/features/counter.js
@@ -14,7 +14,9 @@ const counterSlice = createSlice({
   initialState,
   reducers: {
     incrementMarbleAmount: (state) => {
-      state.marbleAmount += 1;
+      if (state.marbleAmount < state.marbleContainer.capacity)
+        state.marbleAmount += 1;
+      else state.thrownAmount += 1;
     },
     resetMarbleAmount: () => initialState,
     storeIntervalId: (state, action) => {


### PR DESCRIPTION
Ajout de la séquence avec rupture de la poche, apparition du sac de piètre facture, puis rupture de ce sac à son tour

- ajout d'un nouvel élément dans le store: marbleContainer : un objet avec un nom et une capacité
- si le nombre de bille égale la capacité, les billes ne sont plus ajouté dedans mais jeté par terre
- ajout de la phrase pour prévenir de la rupture imminente de la poche à t= 25 billes (décalé de 5 billes par rapport à la spec du kanban pour éviter d'arriver en même temps que le bouton "augmenter l'univers des possible")
- rupture de la poche à t = 35billes avec un useEffect
- lorsque le container change et si les billes sont trop nombreuse par rapport à la capacité du nouveau conteneur, l'excédent est jeté par terre.
- création d'un nouvel élément dans le store pour sauvegarder la quantité de billes actuelle pour déterminer quand faire apparaître la suite (cheapBagEvent). 
- après 5 billes apparition de la phrase sur le sac de piètre facture
- encore 5 billes plus tard apparition du bouton pour le ramasser (la spec n'était pas claire, à voir si on groupe les 2 événements)
- ramasser le sac dispatch l'évent pour le changement de marbleContainer avec une capacité double.
- le useEffect se redéclenche comme précédemment lorsque ça s'approche de la capacité
- après ces événements il n'y a plus de possibilité de ramasser les billes pour le moment